### PR TITLE
Drops tutorial link for now

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -206,7 +206,6 @@
     <h2>Interested in trying Charmed OSM?</h2>
     <p class="p-heading--four">Tell us your NFV story and talk to a Canonical telco expert.</p>
     <p><a href="/contact-us" class="p-button--positive">Get in touch</a></p>
-    <p><a href="https://tutorials.ubuntu.com" class="p-link--inverted">Try it yourself&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 <section class="p-strip--light">


### PR DESCRIPTION
db3585817d28ebafb69adaddbf3126ab70e3d0dd removed one of the links to the not-yet-existing OSM tutorial. This removes the other.