### PR TITLE
Clarifies tutorial links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
         Automate deployment and operations of network functions, and benefit from reduced operational costs, by using an open source implementation of ETSI NFV MANO. To improve the stability of deployments and provide telcos with a production-grade platform, Canonical delivers a pure upstream OSM distribution &mdash; Charmed OSM. As a key contributor to the OSM project, we are excited to help you on your NFV journey.
       </p>
       <p><a href="/contact-us" class="p-button--positive">Get in touch</a></p>
-      <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Get Started with Charmed OSM&nbsp;&rsaquo;</a></p>
+      <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Tutorial: Get started with Charmed OSM&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/e95779ea-opensource-MANO-white.svg" width="300" height="109"
@@ -210,7 +210,7 @@
     <h2>Interested in trying Charmed OSM?</h2>
     <p class="p-heading--four">Tell us your NFV story and talk to a Canonical telco expert.</p>
     <p><a href="/contact-us" class="p-button--positive">Get in touch</a></p>
-    <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Try it yourself&nbsp;&rsaquo;</a></p>
+    <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Tutorial: Try it yourself&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 <section class="p-strip--light">

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
         Automate deployment and operations of network functions, and benefit from reduced operational costs, by using an open source implementation of ETSI NFV MANO. To improve the stability of deployments and provide telcos with a production-grade platform, Canonical delivers a pure upstream OSM distribution &mdash; Charmed OSM. As a key contributor to the OSM project, we are excited to help you on your NFV journey.
       </p>
       <p><a href="/contact-us" class="p-button--positive">Get in touch</a></p>
-      <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted">Get Started with Charmed OSM&nbsp;&rsaquo;</a></p>
+      <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Get Started with Charmed OSM&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/e95779ea-opensource-MANO-white.svg" width="300" height="109"
@@ -210,7 +210,7 @@
     <h2>Interested in trying Charmed OSM?</h2>
     <p class="p-heading--four">Tell us your NFV story and talk to a Canonical telco expert.</p>
     <p><a href="/contact-us" class="p-button--positive">Get in touch</a></p>
-    <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted">Try it yourself&nbsp;&rsaquo;</a></p>
+    <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Try it yourself&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 <section class="p-strip--light">


### PR DESCRIPTION
## Done

- Marks tutorial links as external links
- Introduces tutorial links as “Tutorial:” where it’s not already mentioned

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8042/
- Look at the three links to the tutorial

## Issue / Card

None