### PR TITLE
Enable multi stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,5 @@ run
 .env.local
 
 # Node is only needed for building, not running
-package.json
 node_modules
 yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,56 @@
+# syntax=docker/dockerfile:experimental
+
+# Build stage: Install python dependencies
+# ===
+FROM ubuntu:bionic AS python-dependencies
+RUN apt update && apt install --no-install-recommends --yes python3 python3-pip python3-setuptools
+ADD requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
+
+# Build stage: Install yarn dependencies
+# ===
+FROM node:10-slim AS yarn-dependencies
+WORKDIR /srv
+ADD package.json .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+
+# Build stage: Run "yarn run build-js"
+# ===
+FROM yarn-dependencies AS build-js
+ADD . .
+RUN yarn run build-js
+
+# Build stage: Run "yarn run build-css"
+# ===
+FROM yarn-dependencies AS build-css
+ADD . .
+RUN yarn run build-css
+
+
+# # Build the production image
+# # ===
 FROM ubuntu:bionic
+
+# Install python and import python dependencies
+ADD . .
+RUN apt update && apt install --no-install-recommends --yes python3 python3-lib2to3 python3-pkg-resources
+COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
+COPY --from=python-dependencies /root/.local/bin /root/.local/bin
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Set up environment
 ENV LANG C.UTF-8
 WORKDIR /srv
 
-# System dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
+# Import code, build assets and mirror list
+ADD . .
+RUN rm -rf package.json yarn.lock
+COPY --from=build-css /srv/static/css static/css
+COPY --from=build-js /srv/static/js static/js
 
-# Set git commit ID
-ARG COMMIT_ID
-ENV COMMIT_ID "${COMMIT_ID}"
-ENV TALISKER_REVISION_ID "${COMMIT_ID}"
-
-# Import code, install code dependencies
-COPY . .
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+# Set build id (standardized)
+ARG BUILD_ID
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
## Done

- [x] Fix js not copying (global-nav missing)
- [x] Implemented multistage build to reduce docker image sizes using reference from ubuntu.com
- [x] Reverted `yarn.lock` updates

## QA

- Changes should not affect site
- Check image size: `docker build --tag myimage && docker images` check myimage size
- Revision ID is correctly added in the headers: `docker build --tag myimage --build-arg BUILD_ID=myfakeid .`
- `docker run -ti -p 8111:80 myimage`
- `curl -I http://localhost:8111` to see if headers display "myfakeid"


## Issue / Card

- Multistage builds issue (WUB Fix #2142)
- Standardize build-ids (WUB Fix #2096)