### PR TITLE
“Suscribe” > “Subscribe”

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -258,7 +258,7 @@
           </li>
           <li class="p-list__item">
             <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-            <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Suscribe now</button></span>
+            <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
             <input type="hidden" name="Consent_to_Processing__c" value="yes">
             <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
             <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">


### PR DESCRIPTION
## Done

Changed “Suscribe now” to “Subscribe now”

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8042/
- Scroll to the “Sign up for our monthly Cloud newsletter” section and look at the button