### PR TITLE
Remove unused files for docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,10 @@
 cache.sqlite
 README.md
 HACKING.md
+LICENSE
+tests
+Dockerfile
+renovate.json
 
 # The run script isn't needed
 run
@@ -20,4 +24,3 @@ run
 
 # Node is only needed for building, not running
 node_modules
-yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /srv
 
 # Import code, build assets and mirror list
 ADD . .
-RUN rm -rf package.json yarn.lock
+RUN rm -rf package.json yarn.lock requirements.txt
 COPY --from=build-css /srv/static/css static/css
 COPY --from=build-js /srv/static/js static/js
 


### PR DESCRIPTION
## Done

Remove files that are not necessary in the docker image ran in production

# QA

- `DOCKER_BUILDKIT=1 docker build --tag charmed-osm.com .`
- `docker run -ti -p 8022:80 charmed-osm.com`
- in another terminal: `docker ps`
-  `docker exec -it <CONTAINER_ID> /bin/bash`
- `ls -a`
- Make sure you only get the useful files
- `exit`
- ` docker images | grep charmed-osm.com`
- For this one it shouldn't change too much but for others the size might vary (especially with the test folder: snapcraft I am looking at you directly)