### PR TITLE
Add copy doc

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1mKfttykmrc4ub_LkqdRGIE_x9WgR1NGr7ulxrLvIZXk/edit{% endblock meta_copydoc %}
+
+
 {% block content %}
 <section class="p-strip--header is-dark">
   <div class="row u-vertically-center u-equal-height">


### PR DESCRIPTION
## Done

- Added the meta copydoc to the index page

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://localhost:8042/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that they copydoc extenstion works and the correct doc opens
