### PR TITLE
Add link to osm-hackfests page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
         <a href="/contact-us" class="p-button--positive">Get in touch</a>
       </p>
       <p>
-        <a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Get started with Charmed OSM</a>
+        <a href="https://juju.is/tutorials/charmed-osm-get-started" class="p-link--inverted p-link--external">Get started with Charmed OSM</a>
       </p>
       <p class="u-no-margin--bottom">
         <a href="/osm-hackfests" class="p-link--inverted">Discover Canonical&rsquo;s contribution to OSM&nbsp;&rsaquo;</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,8 +16,15 @@
       <p>
         Automate deployment and operations of network functions, and benefit from reduced operational costs, by using an open source implementation of ETSI NFV MANO. To improve the stability of deployments and provide telcos with a production-grade platform, Canonical delivers a pure upstream OSM distribution &mdash; Charmed OSM. As a key contributor to the Open Source MANO project, we are excited to help you on your NFV journey.
       </p>
-      <p><a href="/contact-us" class="p-button--positive">Get in touch</a></p>
-      <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Get started with Charmed OSM</a></p>
+      <p>
+        <a href="/contact-us" class="p-button--positive">Get in touch</a>
+      </p>
+      <p>
+        <a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Get started with Charmed OSM</a>
+      </p>
+      <p class="u-no-margin--bottom">
+        <a href="/osm-hackfests" class="p-link--inverted">Discover Canonical&rsquo;s contribution to OSM&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/e95779ea-opensource-MANO-white.svg" width="300" height="109"


### PR DESCRIPTION
## Done

- Add link to hero to `/osm-hackfests` 

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8042/
- Check the `Discover Canonical’s contribution to OSM` link points to /osm-hackfests


## Issue / Card

Fixes #69 

