### PR TITLE
Move blog widget to after content

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,10 +33,6 @@
   </div>
 </section>
 
-{% with section_classes='p-strip is-deep is-bordered', heading_topic='OSM', tag_name='osm', tag_id='3527', limit='4' %}
-  {% include "shared/_latest_news_strip.html" %}
-{% endwith %}
-
 <section class="p-strip">
   <div class="row">
     <h2>What is Open Source MANO?</h2>
@@ -236,6 +232,7 @@
     <p><a href="https://tutorials.ubuntu.com/tutorial/charmed-osm-get-started" class="p-link--inverted p-link--external">Try it yourself</a></p>
   </div>
 </section>
+
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Learn more</h2>
@@ -247,6 +244,11 @@
     </ul>
   </div>
 </section>
+
+{% with section_classes='p-strip is-deep is-bordered', heading_topic='OSM', tag_name='osm', tag_id='3527', limit='4' %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
+
 <section class="p-strip is-bordered">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

- Move blog widget to further down as requested in [copy doc](https://docs.google.com/document/d/1mKfttykmrc4ub_LkqdRGIE_x9WgR1NGr7ulxrLvIZXk/edit?ts=6040b961#heading=h.ja6aeh54os48)

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8042/
- Check blogs appear at the bottom of the page after the learn more section as requested


## Screenshots


![image](https://user-images.githubusercontent.com/58959073/109958547-3d6bf000-7cde-11eb-881e-85fc5e133fb3.png)
