### PR TITLE
Add sitemap endpoint to charmed-osm

### DIFF
--- a/templates/sitemap/sitemap-index.xml
+++ b/templates/sitemap/sitemap-index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://charmed-osm.com/</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://charmed-osm.com/osm-hackfests</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,3 +1,5 @@
+import flask
+
 from canonicalwebteam.flask_base.app import FlaskBase
 from flask import render_template
 
@@ -40,3 +42,12 @@ def contact_thanks_you():
 @app.route("/contact-us/contact-modal")
 def contact_modal():
     return render_template("/contact-us/contact-modal.html")
+
+
+@app.route("/sitemap.xml")
+def sitemap_index():
+    xml_sitemap = flask.render_template("sitemap/sitemap-index.xml")
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+
+    return response


### PR DESCRIPTION
## Done

- Add Sitemaps to `charmed-osm`

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8042/sitemap.xml
- Remove the charmed-osm URL and replace with the demo/localhost link
- Check it works and the sitemap is there


## Issue / Card

Fixes #
