### PR TITLE
Add canonicalUpdatesOptIn2 field so there is no form field clashing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -282,7 +282,7 @@
           <li class="mktField mktLblRight p-list__item">
             <span class="mktInput mktLblRight">
               <input class="mktFormCheckbox" name="canonicalUpdatesOptIn2" id="canonicalUpdatesOptIn2" value="yes" type="checkbox">
-              <label class="contextual-footer__text--label" for=""><small>Also notify me of new products and events.&nbsp;<span class="mktFormMsg"></span></small></label>
+              <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn2"><small>Also notify me of new products and events.&nbsp;<span class="mktFormMsg"></span></small></label>
             </span>
           </li>
           <li class="p-list__item u-no-margin--top">

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,7 +118,7 @@
       <h3>Production grade deployments for Telcos</h3>
       <p>Canonical&rsquo;s Charmed OSM distribution can be deployed in a highly available mode which is resilient against failures and allows telcos to meet their availability goal and making charmed OSM their prime choice.</p>
       <p>
-        <a href="https://ubuntu.com/telco/osm" class="p-link--external">Charmed OSM for Telcos</a> 
+        <a href="https://ubuntu.com/telco/osm" class="p-link--external">Charmed OSM for Telcos</a>
       </p>
     </div>
   </div>
@@ -143,8 +143,8 @@
       <h3>Onboarding network functions</h3>
       <p>Charmed OSM provides a platform to easily migrate your traditional telco functions to virtualized and cloud-native environments. It also ensures the easy integration of your network function with other existing components.</p>
       <p>
-        <a href="https://ubuntu.com/telco/osm/onboarding-network-functions" class="p-link--external">Onboard your network functions</a> 
-      </p>  
+        <a href="https://ubuntu.com/telco/osm/onboarding-network-functions" class="p-link--external">Onboard your network functions</a>
+      </p>
   </div>
   </div>
 </section>
@@ -166,7 +166,7 @@
     <div class="col-6">
       <h3 class="p-heading--four">Any Kubernetes</h3>
       <p>
-        Being vendor&dash;neutral, Charmed OSM can run on any Kubernetes platform. Simply spin up your Kubernetes cluster and deploy Charmed OSM on top of it.  For cloud&dash;native workload deployments by OSM, you can use juju bundles or helm charts to onboard on any kubernetes. 
+        Being vendor&dash;neutral, Charmed OSM can run on any Kubernetes platform. Simply spin up your Kubernetes cluster and deploy Charmed OSM on top of it.  For cloud&dash;native workload deployments by OSM, you can use juju bundles or helm charts to onboard on any kubernetes.
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
@@ -281,8 +281,8 @@
           </li>
           <li class="mktField mktLblRight p-list__item">
             <span class="mktInput mktLblRight">
-              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox">
-              <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn"><small>Also notify me of new products and events.&nbsp;<span class="mktFormMsg"></span></small></label>
+              <input class="mktFormCheckbox" name="canonicalUpdatesOptIn2" id="canonicalUpdatesOptIn2" value="yes" type="checkbox">
+              <label class="contextual-footer__text--label" for=""><small>Also notify me of new products and events.&nbsp;<span class="mktFormMsg"></span></small></label>
             </span>
           </li>
           <li class="p-list__item u-no-margin--top">


### PR DESCRIPTION
## Done

- on pages with more than one form, the `canonicalUpdatesOptIn` field was clashing as they are on all forms
- created a new `canonicalUpdatesOptIn2` field in marketo
- created a smart campaign to populate the `canonicalUpdatesOptIn` field with the `canonicalUpdatesOptIn2` data
- used the new field in the newsletter form in the footer of the page

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8042/
- Open the modal contact us and see that you can use the checkbox on the modal for 'Also notify me of new products and events.'
- Go to the footer and see that you can use the checkbox for the newsletter sign-up for 'Also notify me of new products and events.'
- Extra credit, go to marketo and see that the `canonicalUpdatesOptIn` is the same as `canonicalUpdatesOptIn2`

## Issue / Card

Fixes #97

## Screenshots

![image](https://user-images.githubusercontent.com/441217/132839100-2dad4aa4-6268-4323-ac34-faccaf53db1d.png)

![image](https://user-images.githubusercontent.com/441217/132839198-c0a71ce1-0cb4-40c4-9322-a5c573e692a0.png)
