### PR TITLE
Add navigation dropdown menu on small screens

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -6,10 +6,12 @@
           Charmed OSM
         </a>
       </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
-      <ul class="p-navigation__items" role="menu">
-        <li class="p-navigation__item {% if request.path in ['/osm-hackfests'] %}is-selected{% endif %}" role="menuitem">
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item {% if request.path in ['/osm-hackfests'] %}is-selected{% endif %}">
           <a class="p-navigation__link" href="/osm-hackfests">OSM Hackfests</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- Adds in the option to open and close the navigation menu on smaller screens.
- Removes 'role' tags from navigation as they are not in the vanilla pattern.

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8042/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open on small screen and check the 'menu' button is visible and functional.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/charmed-osm.com/issues/128
