### PR TITLE
add video tutorial links to homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -92,6 +92,8 @@
         </div>
       </li>
     </ul>
+
+    <p>To have a deep dive of <a href="https://www.youtube.com/watch?v=3EWjL6pIXe0">OSM architecture</a> and <a href="https://www.youtube.com/watch?v=DJhtjnWdfi8">OSM installation</a>, please see the video tutorials. </p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Adds a couple of links to video tutorials according to the [copy doc](https://docs.google.com/document/u/1/d/1mKfttykmrc4ub_LkqdRGIE_x9WgR1NGr7ulxrLvIZXk/edit?disco=AAAAXWEOzZY&usp=comment_email_document&ts=6243235f&usp_dm=false)

## QA

- View the site in your web browser at: https://charmed-osm-com-143.demos.haus/
- See that the changes match the suggestions in the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5012

