### PR TITLE
Fix typo

### DIFF
--- a/templates/osm-hackfests.html
+++ b/templates/osm-hackfests.html
@@ -42,7 +42,7 @@
           <td colspan="4">
             <ul class="p-list">
               <li class="p-list__item">
-                <a href="hhttps://osm.etsi.org/wikipub/index.php/OSM12_Hackfest">OOSM12 Hackfest</a></li>
+                <a href="https://osm.etsi.org/wikipub/index.php/OSM12_Hackfest">OSM12 Hackfest</a></li>
               <li class="p-list__item">
                 (Jan 24 &mdash; Jan 28) 2022 
               </li>


### PR DESCRIPTION
## Done

Fix typo on `/osm-hackfests`

## QA
- Go to `/osm-hackfests`
- Check the `OSM12 Hackfest` link works properly
